### PR TITLE
Added Linux Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Two main phases occur when you press the `Play` button:
   - `WINEDLLOVERRIDES="dinput8.dll=n,b"`
   - `PROTON_USE_WINED3D=1`
   - `STEAM_COMPAT_DATA_PATH="{client-directory}/.proton"`
-  - `STEAM_COMPAT_CLIENT_INSTALL_PAT="{steam-directory}"`
+  - `STEAM_COMPAT_CLIENT_INSTALL_PATH="{steam-directory}"`
 - See [`client/run_linux.go`](https://github.com/I-Am-Dench/nimbus-launcher/blob/main/client/run_linux.go) for more details.
 
 ## Building or Running from Source

--- a/README.md
+++ b/README.md
@@ -57,9 +57,16 @@ Two main phases occur when you press the `Play` button:
 - Intel (x86): Due to Apple dropping support for 32-bit programs, the client will NOT run through the native executable nor the windows executable through external programs such as [wine](https://www.winehq.org/). Playing the game on an Intel based Mac will require the use of an emulator or VM.
 - M1 (ARM): The client may still be able to be launched through [wine](https://www.winehq.org/). This is currently a **work in progress**.
 
-#### Linux (NOT IMPLEMENTED)
+#### Linux
 
-- The client is able to run through [wine](https://www.winehq.org/), but is currently a **work in progress**. 
+- The launcher uses [https://github.com/ValveSoftware/Proton](https://github.com/ValveSoftware/Proton) to run the client and will return an error if the client is run without Proton installed. Patches, however, are still applied even if the game does not run.
+- While it is possible to build/install Proton from source, it is recommended to install it through Steam as the launcher searches through the Steam directories for the latest version.
+- The client is run as `{latest-proton-version}/proton run ./legouniverse.exe` where the current directory is configured to `Client Directory` and the environment variables are:
+  - `WINEDLLOVERRIDES="dinput8.dll=n,b"`
+  - `PROTON_USE_WINED3D=1`
+  - `STEAM_COMPAT_DATA_PATH="{client-directory}/.proton"`
+  - `STEAM_COMPAT_CLIENT_INSTALL_PAT="{steam-directory}"`
+- See [`client/run_linux.go`](https://github.com/I-Am-Dench/nimbus-launcher/blob/main/client/run_linux.go) for more details.
 
 ## Building or Running from Source
 

--- a/app/app.go
+++ b/app/app.go
@@ -316,7 +316,10 @@ func (app *App) PressPlay() {
 
 	app.progressBar.Hide()
 	go func(cmd *exec.Cmd) {
-		cmd.Wait()
+		if err := cmd.Wait(); err != nil {
+			log.Println(err)
+		}
+		log.Println("Client exited.")
 		app.SetNormalState()
 	}(cmd)
 }

--- a/app/app.go
+++ b/app/app.go
@@ -552,11 +552,32 @@ func (app *App) CheckClient() {
 	}
 }
 
+func (app *App) CheckPrerequisites() {
+	if app.client.MeetsPrerequisites() {
+		app.settings.MeetsPrerequisites = true
+		app.settings.Save()
+		return
+	}
+
+	window := nlwindows.NewPrerequisitesWindow(app, func(b bool) {
+		app.settings.MeetsPrerequisites = b
+		app.settings.Save()
+	})
+
+	window.CenterOnScreen()
+	window.RequestFocus()
+	window.Show()
+}
+
 func (app *App) Start() {
 	app.CheckClient()
 
 	if app.settings.CheckPatchesAutomatically {
 		app.CheckForUpdates(app.CurrentServer())
+	}
+
+	if !app.settings.MeetsPrerequisites {
+		go app.CheckPrerequisites()
 	}
 
 	app.main.CenterOnScreen()

--- a/app/nlwindows/info.go
+++ b/app/nlwindows/info.go
@@ -39,6 +39,8 @@ func OpenLicense() {
 		cmd = exec.Command("notepad", path.Join(dir, "LICENSE"))
 	case "darwin":
 		cmd = exec.Command("open", "-t", path.Join(dir, "LICENSE"))
+	case "linux":
+		cmd = exec.Command("xdg-open", path.Join(dir, "LICENSE"))
 	default:
 		log.Printf("OpenLicense: unsupported GOOS: %s", runtime.GOOS)
 		return

--- a/app/nlwindows/prerequisites.go
+++ b/app/nlwindows/prerequisites.go
@@ -1,0 +1,62 @@
+package nlwindows
+
+import (
+	"fmt"
+	"runtime"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/canvas"
+	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/theme"
+	"fyne.io/fyne/v2/widget"
+)
+
+const linuxPrerequisites = `This launcher utilizes [https://github.com/ValveSoftware/Proton](https://github.com/ValveSoftware/Proton) for launching LEGO Universe clients,
+
+but a viable Proton installation could not be found on your system.
+
+Proton is a tool created by Steam for launching Windows compatible games on Linux, and may be
+
+installed via the **Compatibility** tab within Steam settings or by sorting by **Tools** in the Library tab.`
+
+func prereqContainer() *fyne.Container {
+	switch os := runtime.GOOS; os {
+	case "linux":
+		return container.NewStack(
+			widget.NewRichTextFromMarkdown(linuxPrerequisites),
+		)
+	default:
+		return container.NewStack(
+			widget.NewLabel(fmt.Sprintf("Unsupported OS: %s", os)),
+		)
+	}
+}
+
+func NewPrerequisitesWindow(app fyne.App, onClose func(bool)) fyne.Window {
+	window := app.NewWindow("Missing Prerequisites")
+	window.SetIcon(theme.WarningIcon())
+	window.SetFixedSize(true)
+
+	heading := canvas.NewText("Missing Prerequisites", theme.ForegroundColor())
+	heading.TextSize = 16
+
+	dontShowAgain := widget.NewCheck("Don't Show Again", func(b bool) {})
+	ok := widget.NewButton("Done", func() {
+		onClose(dontShowAgain.Checked)
+		window.Close()
+	})
+
+	window.SetContent(
+		container.NewPadded(
+			container.NewVBox(
+				heading, widget.NewSeparator(),
+				container.NewHBox(
+					prereqContainer(),
+				),
+				container.NewBorder(nil, nil, dontShowAgain, ok),
+			),
+		),
+	)
+
+	return window
+}

--- a/client/client.go
+++ b/client/client.go
@@ -9,6 +9,8 @@ type Client interface {
 	SetPath(path string) error
 	IsValid() bool
 	Start() (*exec.Cmd, error)
+
+	MeetsPrerequisites() bool
 }
 
 func NewStandardClient() Client {

--- a/client/run_darwin.go
+++ b/client/run_darwin.go
@@ -11,3 +11,7 @@ import (
 func (client *standardClient) Start() (*exec.Cmd, error) {
 	return nil, errors.New("client start: functionality has not yet been implemented for this system")
 }
+
+func (client *standardClient) MeetsPrerequisites() bool {
+	return true
+}

--- a/client/run_linux.go
+++ b/client/run_linux.go
@@ -110,3 +110,14 @@ func (client *standardClient) Start() (*exec.Cmd, error) {
 
 	return cmd, cmd.Start()
 }
+
+func (client *standardClient) MeetsPrerequisites() bool {
+	proton, _, err := resolveProton()
+	if err == nil {
+		log.Printf("Found Proton installation: %s", proton)
+	} else {
+		log.Print(err)
+	}
+
+	return err == nil
+}

--- a/client/run_linux.go
+++ b/client/run_linux.go
@@ -83,10 +83,17 @@ func (client *standardClient) Start() (*exec.Cmd, error) {
 
 	dir := filepath.Dir(client.path)
 
-	// Setting CompatData directory inside of the client's directory
-	compatData := filepath.Join(dir, ".proton")
+	// compatdata is usually found within ".steam/steam/steamapps/compatdata/{appid}", but since
+	// LEGO Universe is no longer in service and importing it into steam as an
+	// external app appears to generate a random AppId, to guarantee a directory
+	// we'll use "{clientDirectory}/.proton".
+	//
+	// Possible setting for future versions?
+	compatdata := filepath.Join(dir, ".proton")
 
-	os.MkdirAll(compatData, 0755)
+	if err := os.MkdirAll(compatdata, 0755); err != nil {
+		return nil, fmt.Errorf("failed to make compatdata path: %w", err)
+	}
 
 	cmd := exec.Command(proton, "run", client.path)
 	cmd.Dir = dir
@@ -95,7 +102,7 @@ func (client *standardClient) Start() (*exec.Cmd, error) {
 	cmd.Env = append(cmd.Env, []string{
 		"WINEDLLOVERRIDES=dinput8.dll=n,b",
 		"PROTON_USE_WINED3D=1",
-		fmt.Sprintf("STEAM_COMPAT_DATA_PATH=%s", compatData),
+		fmt.Sprintf("STEAM_COMPAT_DATA_PATH=%s", compatdata),
 		fmt.Sprintf("STEAM_COMPAT_CLIENT_INSTALL_PATH=%s", steam),
 	}...)
 

--- a/client/run_linux.go
+++ b/client/run_linux.go
@@ -4,10 +4,84 @@
 package client
 
 import (
-	"errors"
+	"fmt"
+	"log"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"sort"
 )
 
+const (
+	SteamHome = ".steam/steam/"
+
+	ProtonAppId = "2805730"
+)
+
+var (
+	protonPath = ""
+	steamPath  = ""
+)
+
+func findRecentProtonVersion(dir string) (string, error) {
+	versions, err := filepath.Glob(filepath.Join(dir, "Proton*"))
+	if err != nil {
+		return "", err
+	}
+
+	if len(versions) == 0 {
+		return "", fmt.Errorf("no proton versions installed")
+	}
+
+	sort.Strings(versions)
+
+	return filepath.Join(versions[len(versions)-1], "proton"), nil
+}
+
+func init() {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		log.Printf("init: proton: %v", err)
+		return
+	}
+
+	steam, err := filepath.EvalSymlinks(filepath.Join(home, SteamHome))
+	if err != nil {
+		log.Printf("init: proton: %v", err)
+		return
+	}
+
+	log.Printf("init: proton: Found Steam installation at: %s", steam)
+	steamPath = steam
+
+	proton, err := findRecentProtonVersion(filepath.Join(steam, "steamapps", "common"))
+	if err != nil {
+		log.Printf("init: proton: %v", err)
+		return
+	}
+
+	log.Printf("init: proton: Found Proton installation at: %s", proton)
+	protonPath = proton
+}
+
 func (client *standardClient) Start() (*exec.Cmd, error) {
-	return nil, errors.New("client start: functionality has not yet been implemented for this system")
+	dir := filepath.Dir(client.path)
+	compatData := filepath.Join(dir, ".proton")
+
+	os.MkdirAll(compatData, 0755)
+
+	cmd := exec.Command(protonPath, "run", client.path)
+	cmd.Dir = dir
+	cmd.Env = os.Environ()
+
+	cmd.Env = append(cmd.Env, []string{
+		"WINEDLLOVERRIDES=dinput8.dll=n,b",
+		"PROTON_USE_WINED3D=1",
+		fmt.Sprintf("STEAM_COMPAT_DATA_PATH=%s", compatData),
+		fmt.Sprintf("STEAM_COMPAT_CLIENT_INSTALL_PATH=%s", steamPath),
+	}...)
+
+	cmd.Stderr = os.Stdout
+
+	return cmd, cmd.Start()
 }

--- a/client/run_linux_test.go
+++ b/client/run_linux_test.go
@@ -1,0 +1,92 @@
+//go:build linux
+// +build linux
+
+package client_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/I-Am-Dench/nimbus-launcher/client"
+)
+
+type protonVersion struct {
+	Name        string
+	Version     int
+	VersionName string
+}
+
+func (version *protonVersion) WriteVersion(dir string) error {
+	data := []byte(fmt.Sprint(version.Version, " ", version.VersionName))
+
+	if err := os.WriteFile(filepath.Join(dir, version.Name, "version"), data, 0755); err != nil {
+		return fmt.Errorf("write version: %w", err)
+	}
+
+	return nil
+}
+
+func (version *protonVersion) TestRecentVersion(dir string) error {
+	proton, err := client.FindRecentProtonVersion(dir)
+	if err != nil {
+		return err
+	}
+
+	if dir := filepath.Base(filepath.Dir(proton)); dir != version.Name {
+		return fmt.Errorf("expected \"%s\", but got \"%s\"", version.Name, dir)
+	}
+
+	return nil
+}
+
+func TestFindRecentProtonVersion(t *testing.T) {
+	temp, err := os.MkdirTemp(".", "client_test_*")
+	if err != nil {
+		t.Fatalf("test find proton: %v", err)
+	}
+	defer os.RemoveAll(temp)
+
+	versions := []protonVersion{
+		{"Proton 1.0", 100, "1.0"},
+		{"Proton 2.0", 128, "2.0"},
+		{"Proton 3.0", 339, "3.0"},
+		{"Proton 4.0 (Beta)", 450, "4.0-b"},
+		{"Proton 4.0", 507, "4.0"},
+	}
+
+	for _, version := range versions {
+		if err := os.MkdirAll(filepath.Join(temp, version.Name), 0755); err != nil {
+			t.Fatalf("test find proton: %v", err)
+		}
+
+		if err := version.WriteVersion(temp); err != nil {
+			t.Fatalf("test find proton: %v", err)
+		}
+	}
+
+	t.Log("TEST: recent version")
+	if err := versions[4].TestRecentVersion(temp); err != nil {
+		t.Errorf("test find proton: recent version: %v", err)
+	}
+
+	t.Log("TEST: beta version")
+	versions[4].Version = 0
+	if err := versions[4].WriteVersion(temp); err != nil {
+		t.Errorf("test find proton: %v", err)
+	}
+
+	if err := versions[3].TestRecentVersion(temp); err != nil {
+		t.Errorf("test find proton: beta version: %v", err)
+	}
+
+	t.Log("TEST: deleted version")
+	if err := os.Remove(filepath.Join(temp, versions[3].Name, "version")); err != nil {
+		t.Fatalf("test find proton: %v", err)
+	}
+
+	if err := versions[2].TestRecentVersion(temp); err != nil {
+		t.Errorf("test find proton: deleted version: %v", err)
+	}
+}

--- a/client/run_win.go
+++ b/client/run_win.go
@@ -13,3 +13,7 @@ func (client standardClient) Start() (*exec.Cmd, error) {
 	cmd.Dir = filepath.Dir(client.path)
 	return cmd, cmd.Start()
 }
+
+func (client standardClient) MeetsPrerequisites() bool {
+	return true
+}

--- a/release/release_linux.sh
+++ b/release/release_linux.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+cd "$(dirname $0)"
+
+rm -rf launcher
+mkdir launcher
+
+go build -tags release -o ./launcher/nimbus-launcher ..
+cp ../LICENSE ./launcher
+
+zip -r ../launcher-linux.zip ./launcher

--- a/resource/localdata_linux.go
+++ b/resource/localdata_linux.go
@@ -16,5 +16,5 @@ func DefaultApplicationsDirectory() string {
 		log.Println("Using ~/")
 		return "~/"
 	}
-	return filepath.Join(homeDirectory, "games", DEFAULT_DIR_CLIENT)
+	return filepath.Join(homeDirectory, "games")
 }

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -22,7 +22,7 @@ const (
 )
 
 const (
-	DEFAULT_DIR_CLIENT = "LEGO Software/Lego Universe/client"
+	DEFAULT_DIR_CLIENT = "LEGO Software/LEGO Universe/client"
 )
 
 //go:embed embedded/icon.png

--- a/resource/settings.go
+++ b/resource/settings.go
@@ -14,6 +14,7 @@ const (
 type Settings struct {
 	SelectedServer      string `json:"selectedServer"`
 	PreviouslyRunServer string `json:"previouslyRunServer"`
+	MeetsPrerequisites  bool   `json:"meetsPrerequisites"`
 
 	Client struct {
 		Directory            string `json:"directory"`


### PR DESCRIPTION
Added launch support for Linux systems using Steam/Proton  (see #18) as a wrapper for Wine.

Proton configurations are semi-hardcoded. There are no settings, at the moment, to configure which Proton version you want to use. The launcher searches the `steamapps/common` directory for the latest installed version. Version selection may come in a later release.